### PR TITLE
Fixed typo for last recorded PONG - Fatal error

### DIFF
--- a/kismetexternal/__init__.py
+++ b/kismetexternal/__init__.py
@@ -256,7 +256,7 @@ class ExternalInterface(object):
         # shutting down
         try:
             while not self.kill_ioloop:
-                if not self.last_pong == 0 and time.time() - self.last_pont > 5:
+                if not self.last_pong == 0 and time.time() - self.last_pong > 5:
                     raise RuntimeError("No PONG from Kismet in 5 seconds")
 
                 try:


### PR DESCRIPTION
Typo on line 259, "...self.last_pont > 5:", throws a fatal error for kismetexternal plugins when calling the send_ping() function.

Fixed to read: "...self.last_pong > 5:"

Look, ma!  I'm helping!